### PR TITLE
🚀 CI/CD: build.sh 스크립트 수정: Vercel 배포를 위해 src 디렉토리 복사 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 
 # production
 /build
+output
+output/**
 
 # misc
 .DS_Store

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@ cp -R .next ./output/.next
 cp -R public ./output/public
 cp package.json ./output/package.json
 cp next.config.mjs ./output/next.config.mjs
-
+cp -R src ./output/src


### PR DESCRIPTION
- build.sh 파일을 수정하여 src 디렉토리가 output 디렉토리에 포함되도록 변경
- Vercel 배포 과정에서 필요한 모든 파일이 포함되도록 함